### PR TITLE
Updated @angular peer dependencies to resolve npm warning/ng update error for Angular 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-socket-io",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Socket.IO module for Angular 7",
   "main": "index.ts",
   "scripts": {
@@ -32,8 +32,8 @@
     "zone.js": "^0.8.11"
   },
   "peerDependencies": {
-    "@angular/common": "^6.0.0-rc.0 || ^6.0.0",
-    "@angular/core": "^6.0.0-rc.0 || ^6.0.0",
+    "@angular/common": "^6.0.0-rc.0 || ^6.0.0 || ^7.0.0",
+    "@angular/core": "^6.0.0-rc.0 || ^6.0.0 || ^7.0.0",
     "rxjs": "^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`ng update ngx-socket-io`

`Package "ngx-socket-io" has an incompatible peer dependency to "@angular/common" (requires "^6.0.0-rc.0 || ^6.0.0", would install "7.0.3")
Incompatible peer dependencies found. See above.`

Or

`npm install`

`npm WARN ngx-socket-io@2.0.0 requires a peer of @angular/common@^6.0.0-rc.0 || ^6.0.0 but none is installed. You must install peer dependencies yourself.`
`npm WARN ngx-socket-io@2.0.0 requires a peer of @angular/core@^6.0.0-rc.0 || ^6.0.0 but none is installed. You must install peer dependencies yourself.`