### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "core-js": "^2.4.1",
     "reflect-metadata": "^0.1.10",
     "rxjs": "^6.1.0",
-    "socket.io": "^2.0.1",
-    "socket.io-client": "^2.0.1",
+    "socket.io": "^2.2.0",
+    "socket.io-client": "^2.2.0",
     "zone.js": "^0.8.11"
   },
   "peerDependencies": {


### PR DESCRIPTION
Updated dependency version for socket.io, socket.io-client.
**Reason:** 
By default Angular project is using karma which depends on socket.io@2.1.1 but and as socket.io-parser@3.2.0.

 socket.io-parser@3.2.0 has bad code: 
is-buffer.js line 4: 
`var withNativeBuffer = typeof global.Buffer === 'function' && typeof global.Buffer.isBuffer === 'function';
`
**global** is undefined.

Issue was fixed in socket.io-parser@3.3.0