### PR TITLE
Include withCredentials option

### DIFF
--- a/src/config/socket-io.config.ts
+++ b/src/config/socket-io.config.ts
@@ -111,6 +111,10 @@ export interface SocketIoConfig {
      */
     protocols?: any;
     /**
+     * Whether or not cross-site requests should made using credentials such as cookies, authorization headers or TLS client certificates. Setting withCredentials has no effect on same-site requests. Default value: false
+     */
+    withCredentials: boolean;
+    /**
      * Additional headers (then found in socket.handshake.headers object on the server-side). Default value: -
      */
     extraHeaders?: {


### PR DESCRIPTION
The withCredentials option is an important part of the socket.io client configuration. I initially didn't know it was there and no cookies were sent to the backend after updating socket.io versions.
Knowing this option in advance would've helped me a lot.