### PR TITLE
trigger disconnect event when reloading the page

### DIFF
--- a/src/config/socket-io.config.ts
+++ b/src/config/socket-io.config.ts
@@ -120,6 +120,11 @@ export interface SocketIoConfig {
     extraHeaders?: {
       [header: string]: string;
     };
+
+    /**
+     * decide whether to trigger disconnect event when reloading the page or not
+     * */
+    closeOnBeforeunload?: boolean;
     
     // Additional options for NodeJS Engine.IO clients omitted: https://socket.io/docs/client-api/
   };


### PR DESCRIPTION
Add option to trigger disconnect event when reloading the page 
https://socket.io/blog/socket-io-4-1-0/#add-a-way-to-ignore-the-beforeunload-event