### PR TITLE
Export SOCKET_CONFIG_TOKEN

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,3 @@
-export { SocketIoModule }    from './src/socket-io.module';
+export { SocketIoModule, SOCKET_CONFIG_TOKEN } from './src/socket-io.module';
 export { SocketIoConfig } from './src/config/socket-io.config';
 export { WrappedSocket as Socket }   from './src/socket-io.service';


### PR DESCRIPTION
This is needed if one needs to extend a basic configuration with namespaces, for example.