### PR TITLE
Fix socket.of() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,10 @@ The only addition is the `fromEvent` method, which returns an `Observable` that 
 
 ### `socket.of(namespace: string)`
 
-Takes an namespace.
-Works the same as in Socket.IO.
+Takes a namespace and returns an instance based on the current config and the given namespace,
+that is added to the end of the current url.
+See [Namespaces - Client Initialization](https://socket.io/docs/v4/namespaces/#client-initialization).
+Instances are reused based on the namespace.
 
 ### `socket.on(eventName: string, callback: Function)`
 


### PR DESCRIPTION
Socket-io's of() only exists in the server API and it returns a new instance.

For client we must create a new `io()` with the URL containing the namespace. Let's do this and share instances whenever the namespace is reused.