### PR TITLE
Fix and sync api wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,10 @@ The only addition is the `fromEvent` method, which returns an `Observable` that 
 
 ### `socket.of(namespace: string)`
 
-Takes an namespace.
-Works the same as in Socket.IO.
+Takes a namespace and returns an instance based on the current config and the given namespace,
+that is added to the end of the current url.
+See [Namespaces - Client Initialization](https://socket.io/docs/v4/namespaces/#client-initialization).
+Instances are reused based on the namespace.
 
 ### `socket.on(eventName: string, callback: Function)`
 

--- a/src/socket-io.service.ts
+++ b/src/socket-io.service.ts
@@ -82,6 +82,11 @@ export class WrappedSocket {
     return this;
   }
 
+  send(..._args: any[]): this {
+    this.ioSocket.send.apply(this.ioSocket, arguments);
+    return this;
+  }
+
   emitWithAck<T>(_eventName: string, ..._args: any[]): Promise<T> {
     return this.ioSocket.emitWithAck.apply(this.ioSocket, arguments);
   }

--- a/src/socket-io.service.ts
+++ b/src/socket-io.service.ts
@@ -177,7 +177,10 @@ export class WrappedSocket {
     return this;
   }
 
-  volatile() {
-    return this.ioSocket.volatile;
+  get volatile(): this {
+    // this getter has a side-effect of turning the socket instance true,
+    // but it returns the actual instance, so we need to get the value to force the side effect
+    const _ = this.ioSocket.volatile;
+    return this;
   }
 }

--- a/src/socket-io.service.ts
+++ b/src/socket-io.service.ts
@@ -82,6 +82,10 @@ export class WrappedSocket {
     return this;
   }
 
+  emitWithAck<T>(_eventName: string, ..._args: any[]): Promise<T> {
+    return this.ioSocket.emitWithAck.apply(this.ioSocket, arguments);
+  }
+
   removeListener(_eventName: string, _callback?: Function): this {
     this.ioSocket.removeListener.apply(this.ioSocket, arguments);
     return this;

--- a/src/socket-io.service.ts
+++ b/src/socket-io.service.ts
@@ -120,15 +120,15 @@ export class WrappedSocket {
     return new Promise<T>(resolve => this.once(eventName, resolve));
   }
 
-  listeners(eventName: string) {
+  listeners(eventName: string): Function[] {
     return this.ioSocket.listeners(eventName);
   }
 
-  listenersAny() {
+  listenersAny(): Function[] {
     return this.ioSocket.listenersAny();
   }
 
-  listenersAnyOutgoing() {
+  listenersAnyOutgoing(): Function[] {
     return this.ioSocket.listenersAnyOutgoing();
   }
 

--- a/src/socket-io.service.ts
+++ b/src/socket-io.service.ts
@@ -154,6 +154,16 @@ export class WrappedSocket {
     return this;
   }
 
+  offAny(callback?: (event: string, ...args: any[]) => void): this {
+    this.ioSocket.offAny(callback);
+    return this;
+  }
+
+  offAnyOutgoing(callback?: (event: string, ...args: any[]) => void): this {
+    this.ioSocket.offAnyOutgoing(callback);
+    return this;
+  }
+
   onAny(callback: (event: string, ...args: any[]) => void): this {
     this.ioSocket.onAny(callback);
     return this;

--- a/src/socket-io.service.ts
+++ b/src/socket-io.service.ts
@@ -67,13 +67,13 @@ export class WrappedSocket {
     return this;
   }
 
-  connect(callback?: (err: any) => void): this {
-    this.ioSocket.connect(callback);
+  connect(): this {
+    this.ioSocket.connect();
     return this;
   }
 
-  disconnect(_close?: any): this {
-    this.ioSocket.disconnect.apply(this.ioSocket, arguments);
+  disconnect(): this {
+    this.ioSocket.disconnect();
     return this;
   }
 

--- a/src/socket-io.service.ts
+++ b/src/socket-io.service.ts
@@ -202,4 +202,9 @@ export class WrappedSocket {
     const _ = this.ioSocket.volatile;
     return this;
   }
+
+  compress(value: boolean): this {
+    this.ioSocket.compress(value);
+    return this;
+  }
 }

--- a/src/socket-io.service.ts
+++ b/src/socket-io.service.ts
@@ -57,32 +57,39 @@ export class WrappedSocket {
     return created;
   }
 
-  on(eventName: string, callback: Function) {
+  on(eventName: string, callback: Function): this {
     this.ioSocket.on(eventName, callback);
+    return this;
   }
 
-  once(eventName: string, callback: Function) {
+  once(eventName: string, callback: Function): this {
     this.ioSocket.once(eventName, callback);
+    return this;
   }
 
-  connect(callback?: (err: any) => void) {
-    return this.ioSocket.connect(callback);
+  connect(callback?: (err: any) => void): this {
+    this.ioSocket.connect(callback);
+    return this;
   }
 
-  disconnect(_close?: any) {
-    return this.ioSocket.disconnect.apply(this.ioSocket, arguments);
+  disconnect(_close?: any): this {
+    this.ioSocket.disconnect.apply(this.ioSocket, arguments);
+    return this;
   }
 
-  emit(_eventName: string, ..._args: any[]) {
-    return this.ioSocket.emit.apply(this.ioSocket, arguments);
+  emit(_eventName: string, ..._args: any[]): this {
+    this.ioSocket.emit.apply(this.ioSocket, arguments);
+    return this;
   }
 
-  removeListener(_eventName: string, _callback?: Function) {
-    return this.ioSocket.removeListener.apply(this.ioSocket, arguments);
+  removeListener(_eventName: string, _callback?: Function): this {
+    this.ioSocket.removeListener.apply(this.ioSocket, arguments);
+    return this;
   }
 
-  removeAllListeners(_eventName?: string) {
-    return this.ioSocket.removeAllListeners.apply(this.ioSocket, arguments);
+  removeAllListeners(_eventName?: string): this {
+    this.ioSocket.removeAllListeners.apply(this.ioSocket, arguments);
+    return this;
   }
 
   fromEvent<T>(eventName: string): Observable<T> {
@@ -125,41 +132,49 @@ export class WrappedSocket {
     return this.ioSocket.listenersAnyOutgoing();
   }
 
-  off(eventName?: string, listener?: Function[]) {
+  off(eventName?: string, listener?: Function[]): this {
     if (!eventName) {
       // Remove all listeners for all events
-      return this.ioSocket.offAny();
+      this.ioSocket.offAny();
+      return this;
     }
 
     if (eventName && !listener) {
       // Remove all listeners for that event
-      return this.ioSocket.off(eventName);
+      this.ioSocket.off(eventName);
+      return this;
     }
 
     // Removes the specified listener from the listener array for the event named
-    return this.ioSocket.off(eventName, listener);
+    this.ioSocket.off(eventName, listener);
+    return this;
   }
 
-  onAny(callback: (event: string, ...args: any[]) => void) {
-    return this.ioSocket.onAny(callback);
+  onAny(callback: (event: string, ...args: any[]) => void): this {
+    this.ioSocket.onAny(callback);
+    return this;
   }
 
-  onAnyOutgoing(callback: (event: string, ...args: any[]) => void) {
-    return this.ioSocket.onAnyOutgoing(callback);
+  onAnyOutgoing(callback: (event: string, ...args: any[]) => void): this {
+    this.ioSocket.onAnyOutgoing(callback);
+    return this;
   }
 
-  prependAny(callback: (event: string, ...args: any[]) => void) {
-    return this.ioSocket.prependAny(callback);
+  prependAny(callback: (event: string, ...args: any[]) => void): this {
+    this.ioSocket.prependAny(callback);
+    return this;
   }
 
   prependAnyOutgoing(
     callback: (event: string | symbol, ...args: any[]) => void
-  ) {
-    return this.ioSocket.prependAnyOutgoing(callback);
+  ): this {
+    this.ioSocket.prependAnyOutgoing(callback);
+    return this;
   }
 
-  timeout(value: number) {
-    return this.ioSocket.timeout(value);
+  timeout(value: number): this {
+    this.ioSocket.timeout(value);
+    return this;
   }
 
   volatile() {

--- a/src/socket-io.service.ts
+++ b/src/socket-io.service.ts
@@ -203,6 +203,26 @@ export class WrappedSocket {
     return this;
   }
 
+  get active(): boolean {
+    return this.ioSocket.active;
+  }
+
+  get connected(): boolean {
+    return this.ioSocket.connected;
+  }
+
+  get disconnected(): boolean {
+    return this.ioSocket.disconnected;
+  }
+
+  get recovered(): boolean {
+    return this.ioSocket.recovered;
+  }
+
+  get id(): string {
+    return this.ioSocket.id;
+  }
+
   compress(value: boolean): this {
     this.ioSocket.compress(value);
     return this;


### PR DESCRIPTION
Sync the wrapped API with https://socket.io/docs/v4/client-api/ fixing some returns that should be wrapped, `volatile` usage and adding missing methods and attributes.