### PR TITLE
fix(): fixes provider factory

### DIFF
--- a/src/socket-io.module.ts
+++ b/src/socket-io.module.ts
@@ -41,7 +41,7 @@ export const provideSocketIo = (
     { provide: SOCKET_CONFIG_TOKEN, useValue: config },
     {
       provide: WrappedSocket,
-      useFactory: () => SocketFactory,
+      useFactory: SocketFactory,
       deps: [SOCKET_CONFIG_TOKEN],
     },
   ]);


### PR DESCRIPTION
There's a typo in `provideSocketIo` that results in an instance of `SocketFactory` being provided instead of a `WrappedSocket` instance. This PR fixes this, by replacing the arrow function returning `SocketFactory` with `SocketFactory` itself.