### PR TITLE
fix: add missing deps to provideSocketIo func

### DIFF
--- a/src/socket-io.module.ts
+++ b/src/socket-io.module.ts
@@ -43,7 +43,7 @@ export const provideSocketIo = (
     {
       provide: WrappedSocket,
       useFactory: SocketFactory,
-      deps: [SOCKET_CONFIG_TOKEN],
+      deps: [SOCKET_CONFIG_TOKEN, ApplicationRef],
     },
   ]);
 };


### PR DESCRIPTION
When provided through the `provideSocketIo` function, an error is thrown whenever a new value is emitted using the `fromEvent` method.
> ERROR TypeError: Cannot read properties of undefined (reading 'tick')