### PR TITLE
feat: add support for Socket.IO types

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ bootstrapApplication(AppComponent, {
 
 ## Typings
 
+Two typing approaches are supported: the Socket.IO Typing Pattern and the Event Payload Inline Typing.
+
+### Socket.IO Types
+
 The [Socket.IO types](https://socket.io/docs/v4/typescript/) pattern is supported by both `ngx-socket-io` extended and native wrapped funcions.
 
 Example using the following types:
@@ -298,6 +302,44 @@ export class App {
   basicEmit() {
     // Type error if any of the arguments does not match the sequence (number, string, CustomObject) defined in the EmitEvents interface.
     this.socket.emit('basicEmit', 4.9, 'lib', { name: 'ngx', age: 8 });
+  }
+}
+```
+
+### Event Payload Inline Types
+
+Inline typing does not restrict or validate the event names supported by the socket, but it is useful for inferring the types of the parameters used by each event.
+
+For this usage, a type variable must be specified in each socket method call. Example using the types defined previously:
+
+```TS
+export class App {
+
+  fromEventArg?: FromEventSupportsOnlyOneArg;
+
+  constructor(
+    private socket: Socket
+  ) {
+
+    // this.socket.fromEvent return a Observable<FromEventSupportsOnlyOneArg>
+    this.socket.fromEvent<FromEventSupportsOnlyOneArg>('fromEventSig')
+      .pipe(takeUntilDestroyed())
+      .subscribe(arg => this.fromEventArg = arg);
+
+    this.socket.fromEvent<(n: number) => void>('withAck')
+      .pipe(takeUntilDestroyed())
+      .subscribe(callback => callback(Math.random()));
+  }
+
+  noArg() {
+    this.socket.emit<[]>('noArg');
+  }
+
+  basicEmit() {
+    // When emitting events, the parameter types must be informed within an array.
+    this.socket.emit<
+      [number, string, CustomObject]
+      >('basicEmit', 4.9, 'lib', { name: 'ngx', age: 8 });
   }
 }
 ```

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
 export { SocketIoModule, SOCKET_CONFIG_TOKEN, provideSocketIo } from './src/socket-io.module';
 export { SocketIoConfig } from './src/config/socket-io.config';
 export { WrappedSocket as Socket } from './src/socket-io.service';
+export type { AllButLast, First, FirstArg, Last } from './src/socket-io.service';
+export type { DefaultEventsMap, EventNames, EventParams, EventsMap, ReservedOrUserEventNames, ReservedOrUserListener } from '@socket.io/component-emitter';

--- a/src/socket-io.service.ts
+++ b/src/socket-io.service.ts
@@ -1,3 +1,4 @@
+import { ApplicationRef } from '@angular/core';
 import { Observable } from 'rxjs';
 import { share } from 'rxjs/operators';
 
@@ -7,9 +8,22 @@ import type {
   ReservedOrUserListener,
   ReservedOrUserEventNames,
   DefaultEventsMap,
+  EventsMap,
+  EventNames,
+  EventParams,
 } from '@socket.io/component-emitter';
 
-export type IoSocket = Socket;
+import { SocketIoConfig } from './config/socket-io.config';
+
+export type IoSocket<
+  ListenEvents extends EventsMap = DefaultEventsMap,
+  EmitEvents extends EventsMap = ListenEvents,
+> = Socket<ListenEvents, EmitEvents>;
+// socket.io-client internal types for emitWithAck
+export type First<T extends any[]> = T extends [infer F, ...infer L] ? F : any;
+export type Last<T extends any[]> = T extends [...infer H, infer L] ? L : any;
+export type AllButLast<T extends any[]> = T extends [...infer H, infer L] ? H : any[];
+export type FirstArg<T> = T extends (arg: infer Param) => infer Result ? Param : any;
 // This is not exported in the original, but let's export as helpers for those declaring disconnect handlers
 export type DisconnectDescription =
   | Error
@@ -28,19 +42,6 @@ interface SocketReservedEvents {
   ) => void;
 }
 
-type EventNames = ReservedOrUserEventNames<
-  SocketReservedEvents,
-  DefaultEventsMap
->;
-type EventListener<Ev extends EventNames> = ReservedOrUserListener<
-  SocketReservedEvents,
-  DefaultEventsMap,
-  Ev
->;
-type EventParameters<Ev extends EventNames> = Parameters<EventListener<Ev>>;
-type EventPayload<Ev extends EventNames> =
-  EventParameters<Ev> extends [] ? undefined : EventParameters<Ev>[0];
-
 type IgnoredWrapperEvents = 'receiveBuffer' | 'sendBuffer';
 
 type WrappedSocketIface<Wrapper> = {
@@ -53,14 +54,14 @@ type WrappedSocketIface<Wrapper> = {
       : IoSocket[K];
 };
 
-import { SocketIoConfig } from './config/socket-io.config';
-import { ApplicationRef } from '@angular/core';
-
-export class WrappedSocket implements WrappedSocketIface<WrappedSocket> {
-  private readonly subscribersCounter: Record<string, number> = {};
-  private readonly eventObservables$: Record<string, Observable<any>> = {};
+export class WrappedSocket<
+  ListenEvents extends EventsMap = DefaultEventsMap,
+  EmitEvents extends EventsMap = ListenEvents,
+> implements WrappedSocketIface<WrappedSocket> {
+  private readonly subscribersCounter: Partial<Record<ReservedOrUserEventNames<SocketReservedEvents, ListenEvents>, number>> = {};
+  private readonly eventObservables$: Partial<Record<ReservedOrUserEventNames<SocketReservedEvents, ListenEvents>, Observable<any>>> = {};
   private readonly namespaces: Record<string, WrappedSocket> = {};
-  readonly ioSocket: IoSocket;
+  readonly ioSocket: IoSocket<ListenEvents, EmitEvents>;
   private readonly emptyConfig: SocketIoConfig = {
     url: '',
     options: {},
@@ -136,16 +137,19 @@ export class WrappedSocket implements WrappedSocketIface<WrappedSocket> {
     return created;
   }
 
-  on<Ev extends EventNames>(eventName: Ev, callback: EventListener<Ev>): this {
-    this.ioSocket.on(eventName, callback);
+  on<Ev extends ReservedOrUserEventNames<SocketReservedEvents, ListenEvents>>(
+    eventName: Ev,
+    callback: ReservedOrUserListener<SocketReservedEvents, ListenEvents, Ev>
+  ): this {
+    this.ioSocket.on<Ev>(eventName, callback);
     return this;
   }
 
-  once<Ev extends EventNames>(
+  once<Ev extends ReservedOrUserEventNames<SocketReservedEvents, ListenEvents>>(
     eventName: Ev,
-    callback: EventListener<Ev>
+    callback: ReservedOrUserListener<SocketReservedEvents, ListenEvents, Ev>
   ): this {
-    this.ioSocket.once(eventName, callback);
+    this.ioSocket.once<Ev>(eventName, callback);
     return this;
   }
 
@@ -159,8 +163,11 @@ export class WrappedSocket implements WrappedSocketIface<WrappedSocket> {
     return this;
   }
 
-  emit(_eventName: string, ..._args: any[]): this {
-    this.ioSocket.emit.apply(this.ioSocket, arguments);
+  emit<Ev extends EventNames<EmitEvents>>(
+    eventName: Ev,
+    ...args: EventParams<EmitEvents, Ev>
+  ): this {
+    this.ioSocket.emit(eventName, ...args);
     return this;
   }
 
@@ -169,45 +176,51 @@ export class WrappedSocket implements WrappedSocketIface<WrappedSocket> {
     return this;
   }
 
-  emitWithAck<T>(_eventName: string, ..._args: any[]): Promise<T> {
-    return this.ioSocket.emitWithAck.apply(this.ioSocket, arguments);
+  emitWithAck<Ev extends EventNames<EmitEvents>>(
+    eventName: Ev,
+    ...args: AllButLast<EventParams<EmitEvents, Ev>>
+  ): Promise<FirstArg<Last<EventParams<EmitEvents, Ev>>>> {
+    return this.ioSocket.emitWithAck(eventName, ...args);
   }
 
-  removeListener<Ev extends EventNames>(
-    _eventName?: Ev,
-    _callback?: EventListener<Ev>
+  removeListener<
+    Ev extends ReservedOrUserEventNames<SocketReservedEvents, ListenEvents>,
+  >(
+    eventName?: Ev,
+    callback?: ReservedOrUserListener<SocketReservedEvents, ListenEvents, Ev>
   ): this {
-    this.ioSocket.removeListener.apply(this.ioSocket, arguments);
+    this.ioSocket.removeListener<Ev>(eventName, callback);
     return this;
   }
 
-  removeAllListeners<Ev extends EventNames>(_eventName?: Ev): this {
-    this.ioSocket.removeAllListeners.apply(this.ioSocket, arguments);
+  removeAllListeners<
+    Ev extends ReservedOrUserEventNames<SocketReservedEvents, ListenEvents>,
+  >(eventName?: Ev): this {
+    this.ioSocket.removeAllListeners<Ev>(eventName);
     return this;
   }
 
-  fromEvent<T extends EventPayload<Ev>, Ev extends EventNames>(
-    eventName: Ev
-  ): Observable<T> {
+  fromEvent<
+    Ev extends ReservedOrUserEventNames<SocketReservedEvents, ListenEvents>,
+  >(eventName: Ev): Observable<First<EventParams<ListenEvents, Ev>>> {
     if (!this.subscribersCounter[eventName]) {
       this.subscribersCounter[eventName] = 0;
     }
-    this.subscribersCounter[eventName]++;
+    this.subscribersCounter[eventName]!++;
 
     if (!this.eventObservables$[eventName]) {
-      this.eventObservables$[eventName] = new Observable((observer: any) => {
-        const listener = (data: T) => {
+      this.eventObservables$[eventName] = new Observable<
+        First<EventParams<ListenEvents, Ev>>
+      >(observer => {
+        const listener: any = (data: First<EventParams<ListenEvents, Ev>>) => {
           observer.next(data);
           this.appRef.tick();
         };
-        this.ioSocket.on(eventName, listener as EventListener<Ev>);
+        this.ioSocket.on(eventName, listener);
         return () => {
-          this.subscribersCounter[eventName]--;
+          this.subscribersCounter[eventName]!--;
           if (this.subscribersCounter[eventName] === 0) {
-            this.ioSocket.removeListener(
-              eventName,
-              listener as EventListener<Ev>
-            );
+            this.ioSocket.removeListener(eventName, listener);
             delete this.eventObservables$[eventName];
           }
         };
@@ -216,19 +229,27 @@ export class WrappedSocket implements WrappedSocketIface<WrappedSocket> {
     return this.eventObservables$[eventName];
   }
 
-  fromOneTimeEvent<T extends EventPayload<Ev>, Ev extends EventNames>(
+  fromOneTimeEvent<
+    Ev extends ReservedOrUserEventNames<SocketReservedEvents, ListenEvents>,
+  >(
     eventName: Ev
-  ): Promise<T> {
-    return new Promise<T>(resolve =>
-      this.once(eventName, resolve as EventListener<Ev>)
-    );
+  ): Promise<ReservedOrUserListener<SocketReservedEvents, ListenEvents, Ev>> {
+    return new Promise<ReservedOrUserListener<SocketReservedEvents, ListenEvents, Ev>>(resolve => {
+      this.once<Ev>(eventName, resolve as ReservedOrUserListener<SocketReservedEvents, ListenEvents, Ev>)
+    });
   }
 
-  listeners<Ev extends EventNames>(eventName: Ev): EventListener<Ev>[] {
+  listeners<
+    Ev extends ReservedOrUserEventNames<SocketReservedEvents, ListenEvents>,
+  >(
+    eventName: Ev
+  ): ReservedOrUserListener<SocketReservedEvents, ListenEvents, Ev>[] {
     return this.ioSocket.listeners(eventName);
   }
 
-  hasListeners<Ev extends EventNames>(eventName: Ev): boolean {
+  hasListeners<
+    Ev extends ReservedOrUserEventNames<SocketReservedEvents, ListenEvents>,
+  >(eventName: Ev): boolean {
     return this.ioSocket.hasListeners(eventName);
   }
 
@@ -240,11 +261,11 @@ export class WrappedSocket implements WrappedSocketIface<WrappedSocket> {
     return this.ioSocket.listenersAnyOutgoing();
   }
 
-  off<Ev extends EventNames>(
+  off<Ev extends ReservedOrUserEventNames<SocketReservedEvents, ListenEvents>>(
     eventName?: Ev,
-    listener?: EventListener<Ev>
+    listener?: ReservedOrUserListener<SocketReservedEvents, ListenEvents, Ev>
   ): this {
-    this.ioSocket.off(eventName, listener);
+    this.ioSocket.off<Ev>(eventName, listener);
     return this;
   }
 


### PR DESCRIPTION
## Two commits, the first being the core functionality, while the second is an optional enhancement.

### feat: Add support for Socket.IO types

Added support for using Socket.IO typing.

This includes native methods as well as `ngx-socket-io`'s own methods.

The _README.md_ has been updated to include usage examples and a reference [link](https://socket.io/docs/v4/typescript/) to the Socket.IO docs describing usage with TypeScript.

Some types have been exported in _index.ts_ for cases where _WrappedSocket_ is extended and its methods need to be overridden.

**BREAKING**: Only this commit breaks the typing previously supported by `ngx-socket-io`.


### feat: Combine Socket.IO typing with inline typing

This enhancement combines Socket.IO typing with the inline typing previously supported by `ngx-socket-io`.

It should be compatible with both the typing from version **4.8.2** and earlier, as well as the typing from version **4.8.3** and later (when there was a breaking change).

Fixes the error `Expected 2 type arguments, but got 1.` caused by the type change since version **4.8.3**.

_README.md_ changed to include usage examples with inline typing.