### PR TITLE
fix: enable strict compilerOption to prevent errors when importing lib

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 export { SocketIoModule, SOCKET_CONFIG_TOKEN, provideSocketIo } from './src/socket-io.module';
 export { SocketIoConfig } from './src/config/socket-io.config';
 export { WrappedSocket as Socket } from './src/socket-io.service';
-export type { AllButLast, First, FirstArg, Last } from './src/socket-io.service';
+export type { AllButLast, DecorateAcknowledgements, First, FirstArg, Last } from './src/socket-io.service';
 export type { DefaultEventsMap, EventNames, EventParams, EventsMap, ReservedOrUserEventNames, ReservedOrUserListener } from '@socket.io/component-emitter';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,7 @@
     "declaration": true,
     "stripInternal": true,
     "experimentalDecorators": true,
-    "strictNullChecks": true,
-    "noImplicitAny": true,
+    "strict": true,
     "module": "es2015",
     "moduleResolution": "node",
     "paths": {


### PR DESCRIPTION
Enabled all `strict` compiler options to increase code consistency and prevent errors when importing the library into projects that have these same settings enabled.

Fixes rodgc/ngx-socket-io#204